### PR TITLE
Update aws-sdk version

### DIFF
--- a/oops.gemspec
+++ b/oops.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~> 1.11"
+  spec.add_dependency "aws-sdk-v1", "~> 1.61"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
Because KMS is only supported by v2, I want to use aws-sdk v2 for hats. but oops is using old aws-sdk.
Now aws-sdk has v1 gem called `aws-sdk-v1`. with `aws-sdk-v1` we can use both aws-sdk v1 and v2 in a same application.
